### PR TITLE
Update for pypi.org

### DIFF
--- a/firefox-pypi-search.xml
+++ b/firefox-pypi-search.xml
@@ -4,6 +4,5 @@
   <ShortName>PyPI</ShortName>
   <Description>Searches for Python modules in the Python Package Index (PyPI, the Cheese Shop).</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Image width="16" height="16" type="image/x-icon">https://pypi.python.org/favicon.ico</Image>
-  <Url type="text/html" method="GET" template="https://pypi.python.org/pypi?:action=search&amp;term={searchTerms}" />
+  <Url type="text/html" method="GET" template="https://pypi.org/search/?q={searchTerms}" />
 </OpenSearchDescription>


### PR DESCRIPTION
There is no favicon and the domain has changed.